### PR TITLE
Fix underscore handling in titles

### DIFF
--- a/pre_commit_hooks/markdown_links.py
+++ b/pre_commit_hooks/markdown_links.py
@@ -51,7 +51,7 @@ def _make_label(node: Any) -> str:
 
 def _make_anchor(node: Any, used_anchors: Dict[str, int]) -> str:
     """Chooses the appropriate anchor name for a header label."""
-    # Pick out the text fragments that the anchor will be based off
+    # Pick out the text fragments that the anchor will be based off.
     label_parts: List[str] = []
     for child, _ in node.walker():
         if child.t == "code":

--- a/pre_commit_hooks/markdown_links.py
+++ b/pre_commit_hooks/markdown_links.py
@@ -49,9 +49,17 @@ def _make_label(node: Any) -> str:
     return "".join(label)
 
 
-def _make_anchor(label: str, used_anchors: Dict[str, int]) -> str:
+def _make_anchor(node: Any, used_anchors: Dict[str, int]) -> str:
     """Chooses the appropriate anchor name for a header label."""
-    anchor = label.lower().strip()
+    # Pick out the text fragments that the anchor will be based off
+    label_parts: List[str] = []
+    for child, _ in node.walker():
+        if child.t == "code":
+            label_parts.append(child.literal)
+        elif child.t == "text":
+            label_parts.append(child.literal)
+
+    anchor = "".join(label_parts).lower().strip()
     # Imitate GFM anchors. Sadly, the exact format isn't clearly documented
     # anywhere, so this based on experimentation and what others have done to
     # successfully replicate the GitHub anchor mapping.
@@ -108,7 +116,7 @@ def get_links(contents: str) -> Tuple[List[Header], List[Link]]:
             headers.append(
                 Header(
                     label,
-                    _make_anchor(label, used_anchors),
+                    _make_anchor(child, used_anchors),
                     child.level,
                 )
             )

--- a/pre_commit_hooks/markdown_links_test.py
+++ b/pre_commit_hooks/markdown_links_test.py
@@ -60,6 +60,41 @@ class TestMarkdownLinks(unittest.TestCase):
             headers,
         )
         self.assertListEqual([], links)
+    
+    def test_formatting(self) -> None:
+        contents = (
+            "## Package as `package`\n\n"
+            "## Something _italicized_\n\n"
+            "## Something **bolded**\n\n"
+            "## Some _nested **chars `here`** now_\n\n"
+        )
+        headers, links = markdown_links.get_links(contents)
+        self.assertListEqual(
+            [
+                markdown_links.Header(
+                    "Package as `package`",
+                    "package-as-package",
+                    2
+                ),
+                markdown_links.Header(
+                    "Something _italicized_",
+                    "something-italicized",
+                    2
+                ),
+                markdown_links.Header(
+                    "Something **bolded**",
+                    "something-bolded",
+                    2
+                ),
+                markdown_links.Header(
+                    "Some _nested **chars `here`** now_",
+                    "some-nested-chars-here-now",
+                    2
+                ),
+            ],
+            headers,
+        )
+        self.assertListEqual([], links)
 
     def test_duplicates(self) -> None:
         contents = "# Header\n\n## Header\n\n"

--- a/pre_commit_hooks/markdown_links_test.py
+++ b/pre_commit_hooks/markdown_links_test.py
@@ -72,24 +72,18 @@ class TestMarkdownLinks(unittest.TestCase):
         self.assertListEqual(
             [
                 markdown_links.Header(
-                    "Package as `package`",
-                    "package-as-package",
-                    2
+                    "Package as `package`", "package-as-package", 2
                 ),
                 markdown_links.Header(
-                    "Something _italicized_",
-                    "something-italicized",
-                    2
+                    "Something _italicized_", "something-italicized", 2
                 ),
                 markdown_links.Header(
-                    "Something **bolded**",
-                    "something-bolded",
-                    2
+                    "Something **bolded**", "something-bolded", 2
                 ),
                 markdown_links.Header(
                     "Some _nested **chars `here`** now_",
                     "some-nested-chars-here-now",
-                    2
+                    2,
                 ),
             ],
             headers,

--- a/pre_commit_hooks/markdown_links_test.py
+++ b/pre_commit_hooks/markdown_links_test.py
@@ -60,6 +60,7 @@ class TestMarkdownLinks(unittest.TestCase):
             headers,
         )
         self.assertListEqual([], links)
+
     def test_formatting(self) -> None:
         contents = (
             "## Package as `package`\n\n"

--- a/pre_commit_hooks/markdown_links_test.py
+++ b/pre_commit_hooks/markdown_links_test.py
@@ -60,7 +60,6 @@ class TestMarkdownLinks(unittest.TestCase):
             headers,
         )
         self.assertListEqual([], links)
-    
     def test_formatting(self) -> None:
         contents = (
             "## Package as `package`\n\n"

--- a/pre_commit_hooks/markdown_toc_test.py
+++ b/pre_commit_hooks/markdown_toc_test.py
@@ -94,10 +94,10 @@ class TestMarkdownToc(file_test_case.FileTestCase):
             "\n\n## Table of contents\n\n"
             "-   [Advanced Find & Replace](#advanced-find--replace)\n"
             "-   [Package as `package`](#package-as-package)\n"
-            "-   [Something _italicized_](#something-_italicized_)\n"
+            "-   [Something _italicized_](#something-italicized)\n"
             "-   [Something **bolded**](#something-bolded)\n"
             "-   [Some _nested **chars `here`** now_]"
-            "(#some-_nested-chars-here-now_)\n"
+            "(#some-nested-chars-here-now)\n"
             "\n"
         )
         body = (


### PR DESCRIPTION
Some markdown formatting is ending up in the generated ToC anchors, specifically emphasis when written with `_`'s. In order to better imitate GFM, those formatting tags should not show up in the output. Care must be taken to ensure `_` still shows up where GitHub would generate it, e.g. a header like `## This_one`.

Fixes #16.