### PR TITLE
Add escaping for comments starting with `-`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ In `.pre-commit-config.yaml`, put:
   args:
       - --copyright
       - |+
-          Copyright YYYY my organizationwith multiple lines
+          Copyright YYYY my organization
+          with multiple lines
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ Do:
       - ''
 ```
 
-`\-` is required to escape a starting `-`. For example, to get HTML-style
-comments, the closing `-->` must be escaped:
+Escaping is not generally supported, but `\-` is required to escape a starting
+`-`. For example, to get HTML-style comments, the closing `-->` must be escaped:
 
 ```yaml
 - id: check-copyright

--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ In `.pre-commit-config.yaml`, put:
   args:
       - --copyright
       - |+
-          Copyright YYYY my organization
-          with multiple lines
+          Copyright YYYY my organizationwith multiple lines
 
 ```
 
@@ -121,6 +120,19 @@ Do:
       - ''
       - '// '
       - ''
+```
+
+`\-` is required to escape a starting `-`. For example, to get HTML-style
+comments, the closing `-->` must be escaped:
+
+```yaml
+- id: check-copyright
+  args:
+      - --custom_format
+      - '\.plist$'
+      - '<!--'
+      - ''
+      - '\-->'
 ```
 
 ### check-google-doc-style

--- a/pre_commit_hooks/check_copyright.py
+++ b/pre_commit_hooks/check_copyright.py
@@ -99,7 +99,7 @@ class _CopyrightValidator(object):
         self,
         copyright: str,
         skip_pattern: str,
-        custom_formats: Optional[List[str]],
+        custom_formats: Optional[List[List[str]]],
     ) -> None:
         """Initializes the list of copyright formats and skipped paths."""
         copyright = copyright.strip("\n")
@@ -111,6 +111,11 @@ class _CopyrightValidator(object):
         self._formats: List[Tuple[re.Pattern, re.Pattern, str]] = []
         if custom_formats:
             for custom_format in custom_formats:
+                for i, x in enumerate(custom_format):
+                    # Dashes are treated as flags by argparse, so special-case
+                    # an escape.
+                    if x.startswith(r"\-"):
+                        custom_format[i] = x[1:]
                 self._add_format(copyright, *custom_format)
         for builtin_format in _BUILTIN_FORMATS:
             self._add_format(copyright, *builtin_format)

--- a/pre_commit_hooks/check_copyright_test.py
+++ b/pre_commit_hooks/check_copyright_test.py
@@ -166,3 +166,24 @@ class TestCheckCopyright(unittest.TestCase):
             f.write("? test\n")
             f.flush()
             self.assertEqual(check_copyright.main(argv=argv), 0)
+
+    def test_custom_format_escaped_dash(self) -> None:
+        with tempfile.NamedTemporaryFile(
+            suffix=".py", mode="w", delete=False
+        ) as f:
+            argv = [
+                "bin",
+                f.name,
+                "--copyright=test",
+                "--custom_format",
+                ".py",
+                "",
+                r"\- ",
+                "",
+            ]
+            f.write("non-copyright content\n")
+            f.flush()
+            self.assertEqual(check_copyright.main(argv=argv), 1)
+            f.write("- test\n")
+            f.flush()
+            self.assertEqual(check_copyright.main(argv=argv), 0)


### PR DESCRIPTION
This is special cased -- I don't think it generally need to be supported, but `-` at the start of a comment is an issue for argparse.

I considered switching flag formats, but I still don't feel great about requiring a separate config file for this. The `\-` approach seemed like a low cost change.

Fixes #17 (FYI @matsjla, although for some reason GH seems not want to let me make you a reviewer, maybe due to the Google org)